### PR TITLE
Fix syntax error, missing closure in LeapYear

### DIFF
--- a/fizzbuzz/README.md
+++ b/fizzbuzz/README.md
@@ -52,3 +52,7 @@ If you'd like to run the `fizzbuzz` method and view the output, run the followin
 ```
 bin/console
 ```
+
+## Step-By-Step Solution
+
+Head over to [https://github.com/CodingBlackFemales/intro-to-tdd-solutions/pull/5](https://github.com/CodingBlackFemales/intro-to-tdd-solutions/pull/5), where you'll be able to see the individual commits. Each commit represents a step for solving the exercise.

--- a/leap_year/README.md
+++ b/leap_year/README.md
@@ -63,3 +63,7 @@ If you'd like to run the `leap_year` method and view the output, run the followi
 ```
 bin/console
 ```
+
+## Step-By-Step Solution
+
+Head over to [https://github.com/CodingBlackFemales/intro-to-tdd-solutions/pull/6](https://github.com/CodingBlackFemales/intro-to-tdd-solutions/pull/6), where you'll be able to see the individual commits. Each commit represents a step for solving the exercise.

--- a/leap_year/lib/leap_year.rb
+++ b/leap_year/lib/leap_year.rb
@@ -14,3 +14,4 @@ end
 
 def is_divisible_by_100?(year)
   year % 100 == 0
+end

--- a/leap_year/spec/leap_year_spec.rb
+++ b/leap_year/spec/leap_year_spec.rb
@@ -51,4 +51,5 @@ RSpec.describe 'leap_year' do
         expect(leap_year(number)).to be false
       end
     end
+  end
 end


### PR DESCRIPTION
Fixes 2 trivial syntax errors
```
syntax error, unexpected end-of-input, expecting `end'
```